### PR TITLE
Install via package manager

### DIFF
--- a/boxed.yml
+++ b/boxed.yml
@@ -14,12 +14,12 @@
   pre_tasks:
 
     - name: APT update
-      sudo: yes
+      become: yes
       when: ansible_os_family == 'Debian'
       apt: update_cache=yes cache_valid_time=3600
 
     - name: Install Node.js
-      sudo: yes
+      become: yes
       when: ansible_os_family == 'Debian'
       apt: "name={{item}} state=installed"
       with_items:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,8 @@
 # Process
 # -------
 
+statsd_install_from_source: true
+
 statsd_service_name: statsd
 statsd_init_script: /etc/init.d/statsd
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,8 @@
 statsd_install_from_source: true
 
 statsd_service_name: statsd
+statsd_service_manage: yes
+
 statsd_init_script: /etc/init.d/statsd
 
 statsd_user: statsd

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,9 +1,9 @@
 ---
 
 - name: reload statsd
-  sudo: yes
+  become: yes
   service: name=statsd state=reloaded
 
 - name: restart statsd
-  sudo: yes
+  become: yes
   service: name=statsd state=restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,3 +7,4 @@
 - name: restart statsd
   become: yes
   service: name=statsd state=restarted
+  when: statsd_service_manage

--- a/tasks/configure-source.yml
+++ b/tasks/configure-source.yml
@@ -1,0 +1,45 @@
+---
+
+- name: Create user and group for StatsD
+  become: yes
+  user:
+    createhome: no
+    name: "{{statsd_user}}"
+  tags:
+    - conf
+    - statsd
+    - monitoring
+
+- name: Create StatsD directories
+  become: yes
+  file:
+    dest: "{{item}}"
+    state: directory
+  with_items:
+    - "{{statsd_conf_dir}}"
+    - "{{statsd_run_dir}}"
+    - "{{statsd_log_dir}}"
+  tags:
+    - conf
+    - statsd
+    - monitoring
+
+- name: Create StatsD init script
+  become: yes
+  template:
+    src: "{{item}}"
+    dest: "{{statsd_init_script}}"
+    mode: 0755
+  with_first_found:
+    - files:
+        - "init.{{ansible_distribution}}-{{ansible_distribution_release}}"
+        - "init.{{ansible_distribution}}"
+        - "init.{{ansible_os_family}}"
+      paths:
+        - ../templates/
+      skip: true
+  tags:
+    - init
+    - conf
+    - statsd
+    - monitoring

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,28 +1,7 @@
 ---
 
-- name: Create user and group for StatsD
-  sudo: yes
-  user:
-    createhome: no
-    name: "{{statsd_user}}"
-  tags:
-    - conf
-    - statsd
-    - monitoring
-
-- name: Create StatsD directories
-  sudo: yes
-  file:
-    dest: "{{item}}"
-    state: directory
-  with_items:
-    - "{{statsd_conf_dir}}"
-    - "{{statsd_run_dir}}"
-    - "{{statsd_log_dir}}"
-  tags:
-    - conf
-    - statsd
-    - monitoring
+- include: configure-source.yml
+  when: statsd_install_from_source
 
 - name: Configure StatsD
   become: yes
@@ -31,25 +10,6 @@
     dest: "{{statsd_conf_file}}"
   notify: restart statsd
   tags:
-    - conf
-    - statsd
-    - monitoring
-
-- name: Create StatsD init script
-  sudo: yes
-  template:
-    src: "{{item}}"
-    dest: "{{statsd_init_script}}"
-    mode: 0755
-  with_first_found:
-    - files:
-        - "init.{{ansible_distribution}}-{{ansible_distribution_release}}"
-        - "init.{{ansible_distribution}}"
-        - "init.{{ansible_os_family}}"
-      paths:
-        - ../templates/
-  tags:
-    - init
     - conf
     - statsd
     - monitoring

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -25,7 +25,7 @@
     - monitoring
 
 - name: Configure StatsD
-  sudo: yes
+  become: yes
   template:
     src: config.js
     dest: "{{statsd_conf_file}}"
@@ -55,7 +55,7 @@
     - monitoring
 
 - name: Add StatsD to init
-  sudo: yes
+  become: yes
   service:
     name: "{{statsd_service_name}}"
     enabled: yes

--- a/tasks/install-package.yml
+++ b/tasks/install-package.yml
@@ -1,0 +1,5 @@
+---
+
+- name: install statsd package
+  package:
+    name: statsd

--- a/tasks/install-source.yml
+++ b/tasks/install-source.yml
@@ -24,7 +24,7 @@
 
 - name: Install StatsD
   when: statsd_release|changed
-  sudo: yes
+  become: yes
   command: "rsync -av --delete '/tmp/{{statsd_package}}/' '{{statsd_install_dir}}'"
   tags:
     - deps
@@ -32,7 +32,7 @@
     - monitoring
 
 - name: "Update NPM dependencies"
-  sudo: yes
+  become: yes
   npm:
     path: "{{statsd_install_dir}}"
     state: latest
@@ -43,7 +43,7 @@
     - monitoring
 
 - name: "Install extra packages"
-  sudo: yes
+  become: yes
   npm:
     name: "{{item}}"
     path: "{{statsd_install_dir}}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,6 +20,7 @@
   service:
     name: "{{statsd_service_name}}"
     state: running
+  when: statsd_service_manage
   tags:
     - init
     - statsd

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
 - meta: flush_handlers
 
 - name: Ensure StatsD is running
-  sudo: yes
+  become: yes
   service:
     name: "{{statsd_service_name}}"
     state: running

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,12 @@
 # Delegate further configuration to subtasks
 # placed in this same directory.
 
-- include: install.yml
+- include: install-source.yml
+  when: statsd_install_from_source
+
+- include: install-package.yml
+  when: not statsd_install_from_source
+
 - include: configure.yml
 
 # Flush handlers now, so we avoid starting the process and then

--- a/templates/config.js
+++ b/templates/config.js
@@ -191,7 +191,7 @@ automaticConfigReload: {{'true' if statsd_automatic_config_reload else 'false'}}
 {% for key, value in statsd_extra_conf.items() %}
 "{{key}}": {
 {% for key, value in value.items() %}
-	"{{key}}": {{value}},
+	"{{key}}": {{value|to_json}},
 {% endfor %}
 }
 {% endfor %}

--- a/test.yml
+++ b/test.yml
@@ -19,26 +19,26 @@
   pre_tasks:
 
     - name: APT update
-      sudo: yes
+      become: yes
       when: ansible_os_family == 'Debian'
       apt: update_cache=yes cache_valid_time=3600
 
     - name: Install Node.js
-      sudo: yes
+      become: yes
       when: ansible_os_family == 'Debian'
       apt: "name={{item}} state=installed"
       with_items:
         - nodejs
         - npm
     - name: Install Node.js
-      sudo: yes
+      become: yes
       when: ansible_os_family == 'RedHat'
       yum: "name={{item}} state=installed"
       with_items:
         - nodejs
         - npm
     - name: Symlink Node.js
-      sudo: yes
+      become: yes
       file: src=/usr/bin/node dest=/usr/bin/nodejs state=link
 
   roles:


### PR DESCRIPTION
Hi @zenoamaro!
Please consider this PR.
With these changes one is able to install statsd using package manager via `statsd_install_from_source` toggle that is set to true by default and thus making those changes backward-compatible.
And
I've add toggle that one can use for not to start statsd service with this role.
